### PR TITLE
add some global error handling options

### DIFF
--- a/app/jobs/slackathon/slack_command_job.rb
+++ b/app/jobs/slackathon/slack_command_job.rb
@@ -19,19 +19,21 @@ module Slackathon
 
       say(url, body)
     rescue => e
-      say(url, {
-        response_type: "ephemeral",
-        text: <<~TEXT
-          :mac_bomb: Darn - that slash command (#{name.underscore.gsub("_command", "")}) didn't work
-          ```
-          #{e.class}: #{e.message}
-          #{e.backtrace.take(5).map { |line| line.indent(4) }.join("\n")}
-              ...
-          ```
-        TEXT
-      })
+      if Slackathon.report_errors?
+        say(url, {
+          response_type: "ephemeral",
+          text: <<~TEXT
+            :mac_bomb: Darn - that slash command (#{name.underscore.gsub("_command", "")}) didn't work
+            ```
+            #{e.class}: #{e.message}
+            #{e.backtrace.take(5).map { |line| line.indent(4) }.join("\n")}
+                ...
+            ```
+          TEXT
+        })
+      end
 
-      raise e
+      raise e if Slackathon.raise_errors?
     end
 
     private

--- a/lib/slackathon.rb
+++ b/lib/slackathon.rb
@@ -17,4 +17,21 @@ module Slackathon
   def self.queue=(queue)
     @queue = queue
   end
+
+  def self.report_errors?
+    @report_errors = true unless defined?(@report_errors)
+    !!@report_errors
+  end
+
+  def self.report_errors=(val)
+    @report_errors = val
+  end
+
+  def self.raise_errors?
+    !!@raise_errors
+  end
+
+  def self.raise_errors=(val)
+    @raise_errors = val
+  end
 end


### PR DESCRIPTION
We probably don't need to both report an error back to Slack *and* re-raise it (depending on the ActiveJob backend config, this may result in the same failed command being run multiple times). This sets the default to only printing the error message.