### PR TITLE
expose #say for usage within commands

### DIFF
--- a/app/jobs/slackathon/slack_command_job.rb
+++ b/app/jobs/slackathon/slack_command_job.rb
@@ -1,6 +1,3 @@
-require "net/http"
-require "uri"
-
 module Slackathon
   class SlackCommandJob < ApplicationJob
     queue_as Slackathon.queue
@@ -37,14 +34,7 @@ module Slackathon
     private
 
     def say(url, body)
-      uri = URI(url)
-      headers = { "Content-Type" => "application/json" }
-      body = (String === body) ? body : body.to_json
-      response = Net::HTTP.post uri, body, headers
-
-      unless Net::HTTPSuccess === response
-        raise "#{response.code}: #{response.body}"
-      end
+      Slackathon.say(url, body)
     end
   end
 end

--- a/lib/slackathon.rb
+++ b/lib/slackathon.rb
@@ -1,5 +1,7 @@
 require "slackathon/engine"
 require "slackathon/command"
+require "net/http"
+require "uri"
 
 module Slackathon
   def self.verification_token
@@ -16,5 +18,16 @@ module Slackathon
 
   def self.queue=(queue)
     @queue = queue
+  end
+
+  def self.say(url, body)
+    uri = URI(url)
+    headers = { "Content-Type" => "application/json" }
+    body = (String === body) ? body : body.to_json
+    response = Net::HTTP.post uri, body, headers
+
+    unless Net::HTTPSuccess === response
+      raise "#{response.code}: #{response.body}"
+    end
   end
 end

--- a/lib/slackathon/command.rb
+++ b/lib/slackathon/command.rb
@@ -29,5 +29,9 @@ module Slackathon
     private
 
     attr_reader :params
+
+    def say(body)
+      Slackathon.say(params[:response_url], body)
+    end
   end
 end

--- a/lib/slackathon/command.rb
+++ b/lib/slackathon/command.rb
@@ -33,5 +33,35 @@ module Slackathon
     def say(body)
       Slackathon.say(params[:response_url], body)
     end
+
+    # Slack limits responses per URL to 5, so we recommend
+    # not calling this more than 4 times per command
+    def report_progress(data = {})
+      @progress_count ||= 0
+
+      if (@progress_count += 1) > 4
+        warn("do not call Slackathon::Command#report_progress more than 4 times")
+        return
+      end
+
+      say(
+        response_type: :ephemeral,
+        text: format(progress_message, data)
+      )
+    end
+
+    def progress_message
+      "Running command (%<percent>d percent complete)"
+    end
+
+    # this immediate empty response should prevent slack
+    # from thinking there has been a timeout.
+    #
+    # If you expect `call` to take more than 3000ms to return
+    # a response, we recommend you call `ack_receipt` at the
+    # top of the `call` method.
+    def ack_receipt
+      Net::HTTP.get(URI(params[:response_url]))
+    end
   end
 end


### PR DESCRIPTION
- move `SlackCommandJob#say` to `Slackathon.say`, and delegate to it from `SlackCommandJob#say` and `SlackCommand#say`. Makes it possible to send multiple responses from a single command